### PR TITLE
Update popup window

### DIFF
--- a/lua/plugins/autocompletion.lua
+++ b/lua/plugins/autocompletion.lua
@@ -95,6 +95,9 @@ return {
 
     -- (Default) Only show the documentation popup when manually triggered
     completion = {
+      menu = {
+        border = 'rounded',
+      },
       keyword = {
         range = 'prefix',
       },

--- a/lua/plugins/colortheme.lua
+++ b/lua/plugins/colortheme.lua
@@ -41,6 +41,8 @@ return {
         -- Override highlight groups if needed
         group_overrides = {
           FloatBorder = { fg = '#ffffff', bg = c.vscPopupBack },
+          BlinkCmpMenuBorder = { fg = '#ffffff', bg = c.vscPopupBack },
+          BlinkCmpSignatureHelpBorder = { fg = '#ffffff', bg = c.vscPopupBack },
         },
       }
 

--- a/lua/plugins/colortheme.lua
+++ b/lua/plugins/colortheme.lua
@@ -10,9 +10,10 @@ return {
     -- Toggle background transparency
     local bg_transparent = false
 
-    local c = require('vscode.colors').get_colors()
-
     local function setup_vscode()
+      vim.o.background = theme_style
+      local c = require('vscode.colors').get_colors()
+
       require('vscode').setup {
         style = theme_style,
 
@@ -38,7 +39,9 @@ return {
         color_overrides = {},
 
         -- Override highlight groups if needed
-        group_overrides = {},
+        group_overrides = {
+          FloatBorder = { fg = '#ffffff', bg = c.vscPopupBack },
+        },
       }
 
       -- Load the colorscheme

--- a/lua/plugins/lsp.lua
+++ b/lua/plugins/lsp.lua
@@ -30,6 +30,10 @@ return {
     'saghen/blink.cmp',
   },
   config = function()
+    local hover_border = 'rounded'
+    vim.lsp.handlers['textDocument/hover'] = vim.lsp.with(vim.lsp.handlers.hover, { border = hover_border })
+    vim.lsp.handlers['textDocument/signatureHelp'] = vim.lsp.with(vim.lsp.handlers.signature_help, { border = hover_border })
+
     vim.api.nvim_create_autocmd('LspAttach', {
       group = vim.api.nvim_create_augroup('kickstart-lsp-attach', { clear = true }),
       callback = function(event)
@@ -79,6 +83,11 @@ return {
         -- Execute a code action, usually your cursor needs to be on top of an error
         -- or a suggestion from your LSP for this to activate.
         map('<leader>ca', vim.lsp.buf.code_action, '[C]ode [A]ction', { 'n', 'x' })
+
+        -- Show hover documentation from the attached LSP.
+        map('K', function()
+          vim.lsp.buf.hover { border = 'rounded' }
+        end, 'Hover Documentation')
 
         -- WARN: This is not Goto Definition, this is Goto Declaration.
         --  For example, in C this would take you to the header.


### PR DESCRIPTION
Duplicate of https://github.com/zacswider/nvim/pull/21 to retain correct history

Very small popup borders - especially single lines ones - are hard to discern because they are black against a black background. This updates popups to show a white border.

Before
<img width="980" height="390" alt="Screenshot 2026-03-13 at 9 35 36 PM" src="https://github.com/user-attachments/assets/9e739ab2-e402-4df5-a36e-8a139a601b25" />

After
<img width="980" height="400" alt="Screenshot 2026-03-13 at 9 36 22 PM" src="https://github.com/user-attachments/assets/8db2c518-1357-4dfc-9ef0-8b1a6d5e716d" />
